### PR TITLE
SSO-67

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Typically, you will want to run a command like this:
 This will create a markdown file containing a list of repositories, their associated teams and some meta data (like last commit date).
 
 
+## Meta Report
+
+Generate a report of all accessible repositories containing commit dates, default branches and similar data.
+
+Found at `./meta.py`
+
+### Usage
+
+Typically, you will want to run a command like this:
+
+```python ./meta.py --organisation-token ${GITHUB_TOKEN} ```
+
+This will create a markdown file.
+
+
+
 ## Dependency / Software Report
 
 Uses Github preview api to generate a list of all detected software dependencies within all the repositories the token is authorised to access with the team.

--- a/app/meta.py
+++ b/app/meta.py
@@ -1,0 +1,62 @@
+from pprint import pp
+import pandas as pd
+
+from github import Github, Organization, Team, Repository
+from shared import init, rate_limiter, protected_default_branch, out, timestamp_directory
+from meta import get_args, erb
+
+
+def main():
+    path = timestamp_directory("meta")
+    args = get_args()
+
+    out.log(f"Repository meta data")
+    g:Github
+    org:Organization
+    team:Team
+    g, org, team = init(args)
+
+    rate_limiter.CONNECTION = g
+    rate_limiter.check()
+
+    repos = team.get_repos()
+    i = 0
+    t = repos.totalCount
+
+    all = []
+    r:Repository
+    for r in repos:
+        i = i + 1
+        out.group_start(f"[{i}/{t}] Repository [{r.full_name}]")
+        rate_limiter.check()
+        row = {
+                'Repository': f"<a href='{r.html_url}'>{r.full_name}</a>",
+                'Archived?': "Yes" if r.archived else "No",
+                'Default Branch': r.default_branch,
+                'Default Branch Protection?': "Yes" if protected_default_branch(r) else "No",
+                'Open Pull Requests': r.get_pulls(state='open', sort='created', base=r.default_branch).totalCount,
+                'Clone Traffic': r.get_clones_traffic()['count'],
+                'Fork Count': r.forks_count,
+                'Last Commit Date to Default': r.get_branch(r.default_branch).commit.commit.committer.date
+            }
+        out.log(f"Repository [{r.full_name}] archived [{r.archived}] last commit [{row.get('Last Commit Date to Default', None)}]")
+        out.debug(row)
+        all.append(row)
+        out.group_end()
+
+    out.group_start("Output")
+
+    all = sorted(all, key=lambda p: p['Repository'])
+    df = pd.DataFrame(all)
+    df.to_markdown(f"{path}/report.md", index=False)
+    df.to_html(f"{path}/report.html", index=False, border=0)
+
+    out.log("Generating ERB file")
+    erb(path, f"{path}/report.html")
+
+    out.log(f"Generated reports here [{path}]")
+    out.set_var("directory", path)
+    out.group_end()
+
+if __name__ == "__main__":
+    main()

--- a/app/meta/__init__.py
+++ b/app/meta/__init__.py
@@ -1,0 +1,2 @@
+from .args import *
+from .stub import *

--- a/app/meta/args/__init__.py
+++ b/app/meta/args/__init__.py
@@ -1,0 +1,1 @@
+from .handler import *

--- a/app/meta/args/handler.py
+++ b/app/meta/args/handler.py
@@ -1,0 +1,26 @@
+import datetime
+import dateutil.relativedelta
+import argparse
+
+
+def get_args() -> argparse.Namespace:
+    # date handling
+    parser = argparse.ArgumentParser(description='Generate a list of repositories and teams that owns them with some other meta data.')
+
+    org_group = parser.add_argument_group("Orginisation details")
+    org_group.add_argument('--organisation-slug',
+                            help='Slug of org to use for permissions',
+                            default= 'ministryofjustice',
+                            required=True)
+    org_group.add_argument('--organisation-token',
+                            help='GitHub token which has org level access',
+                            required=True)
+
+    team_group = parser.add_argument_group("Team options.")
+    team_group.add_argument('--team-slug',
+                            help='GitHub slug of the team to run against (can be a list, split by comma)',
+                            default='opg',
+                            required=True)
+
+
+    return parser.parse_args()

--- a/app/meta/stub.py
+++ b/app/meta/stub.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from string import Template
+import html
+
+def erb(report_dir:str, report_file_path:str) -> str:
+    """
+    """
+    now = datetime.utcnow().strftime("%Y-%m-%d")
+
+    f = open(report_file_path, 'r')
+    report = f.read()
+    f.close()
+
+    template = Template(
+        """---
+title: Meta
+last_reviewed_on: $date
+review_in: 3 months
+---
+
+# <%= current_page.data.title %>
+
+Listing of all our repositories and meta data.
+
+<div>
+$table
+</div>
+
+### Notes
+
+This was generated via [this script](https://github.com/ministryofjustice/opg-repository-reporting/blob/main/meta.py).
+
+"""
+    )
+    content = template.substitute(date=now, table=report)
+    content = html.unescape(content)
+    f = open(f"{report_dir}/report.html.md.erb", 'w')
+    f.write(content)
+    f.close()

--- a/app/shared/github_extensions/__init__.py
+++ b/app/shared/github_extensions/__init__.py
@@ -3,3 +3,4 @@ from .dependencies import *
 from .pull_requests import *
 from .teams import *
 from .init import *
+from .branch_protection import *

--- a/app/shared/github_extensions/branch_protection.py
+++ b/app/shared/github_extensions/branch_protection.py
@@ -1,0 +1,6 @@
+from github import Repository
+
+def protected_default_branch(repository:Repository) -> bool:
+    default_branch = repository.default_branch
+    b = repository.get_branch(default_branch)
+    return b.protected


### PR DESCRIPTION
Part of SSO-62
Created a replica of the current owners report, but renamed to meta to avoid future conflict
Remove the ownership details from the reporting, instead show branch protection status for the detault branch